### PR TITLE
Update 05 | It is out 19_Feb_2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 Download [AvventoRadio app](https://play.google.com/store/apps/details?id=org.avvento.apps.onlineradio) now and taste the wonderful experience........
 
-AvventoMedia is a non profit religious Bible based organisation focused on flying the gospel to the whole world through production, promotion and publication of Bible based textual, audible and visual content not only to preserve Biblical sanctity but also inculcate Biblical values such as love, faithfulness, joy, peace, patience, kindness, meekness, self control, hope and the like in the society in preparation for life hereafter. 
-AvventoMedia’s content is branded as AvventoProductions on youtube, facebook, soundcloud and mixcloud. 
+AvventoMedia is a non profit religious Bible based organisation focused on flying the gospel to the whole world through production, promotion and publication of Bible based textual, audible and visual content not only to preserve Biblical sanctity but also inculcate Biblical values such as love, faithfulness, joy, peace, patience, kindness, meekness, self control, hope and the like in the society in preparation for life hereafter.
+AvventoMedia’s content is branded as AvventoProductions on youtube, facebook, soundcloud and mixcloud.
 AvventoProductions can also be found on Avvento Online radio here as well as on the free to air 3ABN Uganda Television.
 ### New Features and Fixes
 
@@ -38,15 +38,15 @@ AvventoProductions can also be found on Avvento Online radio here as well as on 
 #### New Features
 - [x] Added Audio Focus in playing radio, pause, play and audio reduce
 - [x] Changed to Avvento new logo
-- [x] UPDATED glide from `4.7.1` to `4.12.0`
 - [x] Support `gif images` in Explore screen
 - [x] Keep Screen awake on Main screen
 
 #### Improved Features
 - [x] Reduced notification Priority to `LOW`
 - [x] Removed Whatsapp menu due to number not yet Registered
+- - [x] UPDATED glide from `4.7.1` to `4.12.0` | constraintlayout from `1.1.3` to `2.1.4` | testing libraries
 
-#### Fixed 
+#### Fixed
 - [x] App Start with Start Listening yet Playing
 
 #### Not yet Fixed

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,15 +2,15 @@ apply plugin: 'com.android.application'
 //apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 30
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "org.avvento.apps.onlineradio"
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdkVersion 30
         versionCode 4
-        versionName "2.0.4"
+        versionName "2.0.5"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
@@ -32,20 +32,19 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'com.google.android.material:material:1.3.0'
     implementation 'org.greenrobot:eventbus:3.2.0'
-    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.github.Vinayrraj:TickerView:v0.1-alpha'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.google.android.play:core:1.10.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     implementation 'com.google.android.exoplayer:exoplayer:2.13.2'
-    implementation 'com.google.android.material:material:1.3.0'
 
     implementation 'androidx.multidex:multidex:2.0.1'
 


### PR DESCRIPTION
---
<center>Changes DONE on _Feb 19, 2023_</center>

---
#### New Features
- [x] Added Audio Focus in playing radio, pause, play and audio reduce
- [x] Changed to Avvento new logo
- [x] UPDATED glide from `4.7.1` to `4.12.0`
- [x] Support `gif images` in Explore screen
- [x] Keep Screen awake on Main screen

#### Improved Features
- [x] Reduced notification Priority to `LOW`
- [x] Removed Whatsapp menu due to number not yet Registered

#### Fixed 
- [x] App Start with Start Listening yet Playing

#### Not yet Fixed
- [x] So far none 